### PR TITLE
Configurable lag time threshold

### DIFF
--- a/src/analysis.py
+++ b/src/analysis.py
@@ -63,7 +63,9 @@ def extract_maximum_growth_rates(growth_rates: pd.DataFrame) -> dict[str, pd.Dat
 
 
 def extract_growth_parameters(
-    growth_rates: dict[str, pd.DataFrame], blank_data: pd.DataFrame
+    growth_rates: dict[str, pd.DataFrame],
+    blank_data: pd.DataFrame,
+    lag_time_threshold: int,
 ) -> pd.DataFrame:
     """Extract growth parameters from data.
 
@@ -84,7 +86,7 @@ def extract_growth_parameters(
     ts = growth_rates["timestamps"]
     gr = growth_rates["growth_rates"]
 
-    lag_time = ts.where(ts > 13).agg("min")
+    lag_time = ts.where(ts > lag_time_threshold).agg("min")
 
     maxidx = gr.where((ts >= 20) & (ts <= 48)).idxmax()
     max_growth_rate = pd.Series({col: gr.at[idx, col] for col, idx in maxidx.items()})

--- a/src/cli.py
+++ b/src/cli.py
@@ -39,6 +39,16 @@ class CLI:
         )
 
         parser.add_argument(
+            "--lag-time-threshold",
+            action="store",
+            help="Minimum lag time (L) to look for (Default: %(default)s).",
+            dest="lag_time_threshold",
+            type=float,
+            default=15.0,
+            required=False,
+        )
+
+        parser.add_argument(
             "-v",
             "--verbose",
             help="Log verbosely if used (show debug messages)",

--- a/src/main.py
+++ b/src/main.py
@@ -51,6 +51,7 @@ def main() -> int:
         growth_parameters = extract_growth_parameters(
             max_growth_rates,
             normalized_blanked_data,
+            lag_time_threshold=args.lag_time_threshold,
         )
     except MTPAnalyzerException as e:
         logging.error(

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -140,6 +140,7 @@ def test_get_growth_parameters():
     actual_growth_parameters = extract_growth_parameters(
         input_growth_rates,
         input_blank_data,
+        lag_time_threshold=15,
     )
 
     expected_growth_parameters = pd.DataFrame(


### PR DESCRIPTION
Make lag time threshold configurable with a command line option, and set the new default to 15 (was 13).

Closes #30.

